### PR TITLE
Add bits per second and packets per second

### DIFF
--- a/tstat_transport/format.py
+++ b/tstat_transport/format.py
@@ -137,6 +137,8 @@ class EntryCapsuleBase(object):
                 ('duration', self.duration),
                 ('num_bits', self.num_bits),
                 ('num_packets', self.num_packets),
+                ('bits_per_second', self.bits_per_second),
+                ('packets_per_second', self.packets_per_second)
             ]
         )
 
@@ -273,9 +275,19 @@ class TcpCapsule(EntryCapsuleBase):
         return self._directional_key('bytes_uniq') * 8
 
     @property
+    def bits_per_second(self):
+        """Get bits_per_second."""
+        return ( round( ( self._directional_key('bytes_uniq') * 8 ) / ( self._static_key('durat') / 1000 ), 2) ) if self._static_key('durat') != 0 else 0
+
+    @property
     def num_packets(self):
         """Get num_packets."""
         return self._directional_key('pkts_data')
+
+    @property
+    def packets_per_second(self):
+        """Get packets_per_second."""
+        return ( round( self._directional_key('pkts_data') / ( self._static_key('durat') / 1000 ), 2) ) if  self._static_key('durat') != 0 else 0
 
     @property
     def start(self):
@@ -302,9 +314,19 @@ class UdpCapsule(EntryCapsuleBase):
         return self._directional_key('bytes_all') * 8
 
     @property
+    def bits_per_second(self):
+        """Get bits_per_second."""
+        return ( round( ( self._directional_key('bytes_all') * 8 ) / ( self._directional_key('durat') / 1000 ), 2) ) if self._directional_key('durat') != 0 else 0
+
+    @property
     def num_packets(self):
         """Get num_packets."""
         return self._directional_key('pkts_all')
+
+    @property
+    def packets_per_second(self):
+        """Get packets_per_second."""
+        return ( round( self._directional_key('pkts_all') / ( self._directional_key('durat') / 1000 ), 2) ) if  self._directional_key('durat') != 0 else 0
 
     @property
     def start(self):


### PR DESCRIPTION
Adds bits per second and packets per second. Certainly this can be calculated based on the data later, but providing it here makes the output more consistent with what you get from nfdump.

If the duration is 0, this returns 0 for both bps and pps, since dividing by zero doesn't work. We have been seeing quite a few large flows (exabytes!) with a duration of 0, so this is needed.