### PR TITLE
Update configparser version requirement to build with CentOS 7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     install_requires=[
         'pika==0.10.0',
-        'configparser>=3.5.0',
+        'configparser==3.5.0b2',
         'six',
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     install_requires=[
         'pika==0.10.0',
-        'configparser==3.5.0',
+        'configparser>=3.5.0',
         'six',
     ],
     classifiers=[


### PR DESCRIPTION
We were unable to build on CentOS 7 because the setup.py file specifies `python-configparser == 3.5.0` while CentOS 7 provides `python-configparser.noarch 0:3.5.0b2-1.el7`

This change to setup.py fixes that issue.