### PR TITLE
Add instance_id tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Default: `rabbit`
 
 The sensor_id element of the message metadata defaults to `socket.gethostname()` - using this flag will set that value manually.
 
+##### --instance
+
+The instance_id element of the message metadata defaults to 0 - using this flag will set that value manually. This makes it possible to differentiate between instances on sensors that have multiple tstat streams.
+
 ##### --single
 
 Process a single "timestamped directory" of files, send JSON and exit. This is primarily for development or debugging.

--- a/bin/tstat_send
+++ b/bin/tstat_send
@@ -38,6 +38,9 @@ def main():
     parser.add_option('-S', '--sensor', metavar='ID',
                       type='string', dest='sensor', default=None,
                       help='Sensor ID to include in meta data (default: gethostbyname()).')
+    parser.add_option('-I', '--instance', metavar='ID',
+                      type='string', dest='instance', default=0,
+                      help='Instance ID to include in meta data (default: 0). Mostly useful if there are multiple TSTAT processes on one sensor.')
     parser.add_option('-s', '--single',
                       dest='single', action='store_true', default=False,
                       help='Only process a single log file - primarily for development.')

--- a/tstat_transport/format.py
+++ b/tstat_transport/format.py
@@ -178,6 +178,7 @@ class EntryCapsuleBase(object):
                 ('dst_port', meta_vals.get('dst_port')),
                 ('protocol', self._protocol),
                 ('sensor_id', self.sensor_id),
+                ('instance_id', self.instance_id),
                 ('flow_type', 'tstat'),
             ]
         )
@@ -216,6 +217,13 @@ class EntryCapsuleBase(object):
             return self._config.options.sensor
         else:
             return socket.gethostname()
+
+    @property
+    def instance_id(self):
+        if self._config.options.instance is not None:
+            return self._config.options.instance
+        else:
+            return 0
 
     def to_json_packet(self):
         """Public wrapper around document method. Primarily for compatability


### PR DESCRIPTION
We've got a use case where we have multiple TSTAT streams on some 100G node -- as such, we'd like to be able to flag which stream ("instance") the data came from. I've implemented this, let me know what you think.