### PR TITLE
Changed tstat_send to escape erroneous quotation marks in the csv file

### DIFF
--- a/bin/tstat_send
+++ b/bin/tstat_send
@@ -11,7 +11,7 @@ import argparse
 
 ## Fixes the PYTHONPATH
 import sys
-sys.path.append('../tstat-transport')
+sys.path.append('..')
 
 
 from tstat_transport.parse import TstatParse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 configparser>=4.0,<4.1
-pika==1.1.0
+pika==0.10.0
 six>=1.14,<1.15
 python-dotenv==0.13.0
 environ-config==20.1.0

--- a/tstat_transport/parse.py
+++ b/tstat_transport/parse.py
@@ -136,7 +136,7 @@ class TstatParse(TstatBase):
                           'processing: {0}'.format(self._get_log(log_path, i)))
 
                 with open(self._get_log(log_path, i), 'r') as(csvfile):
-                    reader = csv.DictReader(csvfile, delimiter=' ')
+                    reader = csv.DictReader(csvfile, delimiter=' ', quoting=csv.QUOTE_NONE)
                     for row in reader:
                         # validate the row before we proceed
                         if not self._check_row(row):


### PR DESCRIPTION
Fixes the issue where tstat_send crashes with a `field_size_error`. This issue was caused because an entry in the tcp_log_complete csv file had an opening quote character which wasn't closed. This caused the csv reader to interpret the following lines of code as one giant field. Adding an additional parameter to the `csv.DictReader` constructor solves this issue.

